### PR TITLE
Use Model.findById() rather than get()

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -119,7 +119,7 @@ class Service {
   }
 
   remove(id, params) {
-    const promise = id === null ? this.find(params) : this.get(id);
+    const promise = id === null ? this.find(params) : this.Model.findById(id);
 
     return promise.then(data => {
       const where = Object.assign({}, params.query);


### PR DESCRIPTION
Calling this.get() from within remove() will not populate params.user object, and if you have a before get hook validating the presence of a user object (i.e. feathers-authentication.hooks.requireAuth) it will throw an error.

This is a bit of a weird situation because of some inconsistencies in the API. update() takes an id and Model.findById() is used so I guess the assumption is the author will validate access, permissions etc in a before update hook. patch() takes an id or params but ultimately does a find and passes the id in to the params.where object, if present. 

This PR follows the update() method of retrieving a single instance for remove().