### PR TITLE
added value conversion for $sort to utils `getOrder`

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -28,7 +28,7 @@ export function errorHandler(error) {
         break;
     }
   }
-  
+
   throw feathersError;
 }
 
@@ -36,7 +36,7 @@ export function getOrder(sort={}) {
   let order = [];
 
   Object.keys(sort).forEach(name =>
-    order.push([ name, sort[name] === 1 ? 'ASC' : 'DESC' ]));
+    order.push([ name, parseInt(sort[name], 10) === 1 ? 'ASC' : 'DESC' ]));
 
   return order;
 }


### PR DESCRIPTION
Solves issue discussed here: https://github.com/feathersjs/feathers/issues/197 with `feathers-sequelize` not correctly converting the `$sort` value to an integer.