### PR TITLE
Use internal methods instead of service methods directly

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,10 @@ You can run this example by using `node examples/app` and going to [localhost:30
 
 ## Changelog
 
+__1.1.0__
+
+- Use internal methods instead of service methods directly  ([#8](https://github.com/feathersjs/feathers-sequelize/issues/8))
+
 __1.0.0__
 
 - First official release

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
   "dependencies": {
     "babel-polyfill": "^6.3.14",
     "feathers-errors": "^1.1.5",
-    "feathers-query-filters": "^1.1.1",
+    "feathers-query-filters": "^1.5.1",
     "uberproto": "^1.1.2"
   },
   "devDependencies": {


### PR DESCRIPTION
This is for https://github.com/feathersjs/feathers/issues/218. Basically, if an adapter uses its own service methods internally (like doing a `get` after removing an item) they can't be the original service methods (like `get`, `create`, `find` etc.) directly since those can be modified by Feathers with mixins and hooks and we do not want those to run in that case.

For this adapter we now provide an internal `_get` (also see #7), `_find` (that ignores pagination) and `_getOrFind` (for patch and remove many).