### PR TITLE
Allow for Sequelize Associations

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -33,7 +33,7 @@ class Service {
       where, order,
       limit: filters.$limit,
       offset: filters.$skip
-    }, include, params.sequelize);
+    }, params.sequelize);
 
     if(filters.$select) {
       q.attributes = filters.$select;

--- a/src/index.js
+++ b/src/index.js
@@ -33,10 +33,14 @@ class Service {
       where, order,
       limit: filters.$limit,
       offset: filters.$skip
-    }, params.sequelize);
+    }, include, params.sequelize);
 
     if(filters.$select) {
       q.attributes = filters.$select;
+    }
+
+    if (query.$associations) {
+      q.include = query.$associations;
     }
 
     return this.Model.findAndCount(q).then(result => {

--- a/src/index.js
+++ b/src/index.js
@@ -39,8 +39,8 @@ class Service {
       q.attributes = filters.$select;
     }
 
-    if (query.$associations) {
-      q.include = query.$associations;
+    if (query.$populate) {
+      q.include = query.$populate;
     }
 
     return this.Model.findAndCount(q).then(result => {


### PR DESCRIPTION
This is very useful for allowing for querying models with associations. Here is an example
```
// posts model
export default function (sequelize) {
  return sequelize.define('post', {
    title: {
      type: Sequelize.TEXT,
    },
  }, {
    classMethods: {
      associate(models) {
        this.belongsTo(models.user);
      },
    },
  });
}

// users model
export default function (sequelize) {
  return sequelize.define('user', {
    name: {
      type: Sequelize.TEXT,
    },
  }, {
    classMethods: {
      associate(models) {
        this.hasMany(models.posts);
      },
    },
  });
}
```

```
// a sample hook to get posts in posts
hook.query = Object.assign({}, { $associations: [{ model: hook.app.service('users').Model }] });
```

This creates the query:
```
SELECT
  "post"."id",
  "post"."userId",
  "post"."title",
  "user"."id",
  "user"."name",
FROM "posts" AS "post"
LEFT OUTER JOIN "users" AS "user" ON
"post"."userId" = "user"."id"
```

Note once you set up the association, sequelize will create the userId column on the sequelize.sync().

Anyway, we find this to be useful in our project. I realize it adds an extra option not in the other ORMs.