### PR TITLE
doc: fix README.md comment.

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ const app = feathers()
 // Removes all database content
 Todo.sync({ force: true });
 
-// Create an in-memory Feathers service with a default page size of 2 items
+// Create an sqlite backed Feathers service with a default page size of 2 items
 // and a maximum size of 4
 app.use('/todos', service({
   Model: Todo,


### PR DESCRIPTION
The example shows a sqlite backed service but the comment incorrectly suggested it was an in-memory service.