### PR TITLE
Added distinct:true to findAllAndCount()

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -44,6 +44,7 @@ class Service {
     return this.Model.findAndCount(q).then(result => {
       return {
         total: result.count,
+        distinct: true,
         limit: filters.$limit,
         skip: filters.$skip || 0,
         data: result.rows

--- a/src/index.js
+++ b/src/index.js
@@ -34,7 +34,8 @@ class Service {
       where,
       order,
       limit: filters.$limit,
-      offset: filters.$skip
+      offset: filters.$skip,
+      distinct: true
     }, params.sequelize);
 
     if (filters.$select) {
@@ -44,7 +45,6 @@ class Service {
     return this.Model.findAndCount(q).then(result => {
       return {
         total: result.count,
-        distinct: true,
         limit: filters.$limit,
         skip: filters.$skip || 0,
         data: result.rows


### PR DESCRIPTION
Adding any includes to the query via an include hook or something like that causes the count to be incorrect.

'distinct:true' results in a distinct count on the primary id of the table.

See:

https://github.com/sequelize/sequelize/issues/6744
and 
https://github.com/sequelize/sequelize/issues/6418