### PR TITLE
Allow "include/through" type queries in feathers sequlize

### DIFF
--- a/package.json
+++ b/package.json
@@ -62,6 +62,7 @@
     "feathers-commons": "^0.8.4",
     "feathers-errors": "^2.0.1",
     "feathers-query-filters": "^2.0.0",
+    "lodash.isstring": "^4.0.1",
     "lodash.omit": "^4.3.0",
     "uberproto": "^1.1.2"
   },

--- a/src/index.js
+++ b/src/index.js
@@ -1,3 +1,4 @@
+import _isString from 'lodash.isstring';
 import omit from 'lodash.omit';
 import Proto from 'uberproto';
 import filter from 'feathers-query-filters';
@@ -29,10 +30,30 @@ class Service {
     const { filters, query } = getFilter(params.query || {});
     const where = utils.getWhere(query);
     const order = utils.getOrder(filters.$sort);
-
+    var include = where.include;
+    if (include) {
+      delete (where.include);
+      if (_isString(include.model)) {
+        include.model = this.Model.modelManager.getModel(include.model);
+      }
+      if (_isString(include.through)) {
+        include.through = this.Model.modelManager.getModel(include.through);
+      }
+      if (include.association) {
+        if (_isString(include.association.source)) {
+          include.association.source = this.Model.modelManager.getModel(
+            include.association.source);
+        }
+        if (_isString(include.association.target)) {
+          include.association.target = this.Model.modelManager.getModel(
+            include.association.target);
+        }
+      }
+    }
     const q = Object.assign({
       where,
       order,
+      include: include,
       limit: filters.$limit,
       offset: filters.$skip
     }, params.sequelize);


### PR DESCRIPTION
 * If we see an include grab it and convert its models to sequelize models

This allows writing "through" style queries as part of the standard service.  
EG: Find all people in a group.

I didn't see any tests about conversion of url arguments to sequelize arguments, so I wasn't sure where to add such a test.  Since it requires adding related test models as well, I was unsure how to proceed.

