### PR TITLE
Enable eager-loading for GET endpoint

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -64,7 +64,16 @@ class Service {
 
   _get (id, params) {
     if(params.sequelize && params.sequelize.include) { //If eager-loading is used, we need to use the find method
-      return this.Model.findAll(Object.assign({where: {id:id}}, params.sequelize)).then(result => {
+      
+      const { filters, query } = getFilter(params.query || {});
+      const where = utils.getWhere(query);
+
+      //Attach where constraints, if any where used.
+      const q = Object.assign({
+        Object.assign({id:id},where)
+      }, params.sequelize);
+
+      return this.Model.findAll(q).then(result => {
         if (result.length===0) throw new errors.NotFound(`No record found for id '${id}'`);
         return result[0];
       })

--- a/src/index.js
+++ b/src/index.js
@@ -64,7 +64,7 @@ class Service {
 
   _get (id, params) {
     if(params.sequelize && params.sequelize.include) { //If eager-loading is used, we need to use the find method
-      const where = utils.getWhere(query);
+      const where = utils.getWhere(params.query);
 
       //Attach where constraints, if any where used.
       const q = Object.assign(

--- a/src/index.js
+++ b/src/index.js
@@ -69,9 +69,9 @@ class Service {
       const where = utils.getWhere(query);
 
       //Attach where constraints, if any where used.
-      const q = Object.assign({
+      const q = Object.assign(
         Object.assign({id:id},where)
-      }, params.sequelize);
+      , params.sequelize);
 
       return this.Model.findAll(q).then(result => {
         if (result.length===0) throw new errors.NotFound(`No record found for id '${id}'`);

--- a/src/index.js
+++ b/src/index.js
@@ -64,8 +64,6 @@ class Service {
 
   _get (id, params) {
     if(params.sequelize && params.sequelize.include) { //If eager-loading is used, we need to use the find method
-      
-      const { filters, query } = getFilter(params.query || {});
       const where = utils.getWhere(query);
 
       //Attach where constraints, if any where used.


### PR DESCRIPTION
sequelize does not support eager-loading when using findById. However when fetching a particular entity, the developer might want to retrieve related associations automatically (as he currently can with the find method).