### PR TITLE
use 'returning: true' for postgres to keep patch and its response atomic

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -17,6 +17,7 @@ class Service {
 
     this.paginate = options.paginate || {};
     this.Model = options.Model;
+    this.dialect = options.Model.sequelize.options.dialect;
     this.id = options.id || 'id';
     this.events = options.events;
   }
@@ -69,7 +70,7 @@ class Service {
       const where = utils.getWhere(params.query);
 
       // Attach 'where' constraints, if any were used.
-      const q = Object.assign({where:Object.assign({id:id},where)}, params.sequelize);
+      const q = Object.assign({where: Object.assign({id: id}, where)}, params.sequelize);
 
       promise = this.Model.findAll(q).then(result => {
         if (result.length === 0) {
@@ -122,17 +123,29 @@ class Service {
     const where = Object.assign({}, filter(params.query || {}).query);
     const mapIds = page => page.data.map(current => current[this.id]);
 
-    // By default we will just query for the one id. For multi patch
-    // we create a list of the ids of all items that will be changed
-    // to re-query them after the update
-    const ids = id === null ? this._find(params)
-        .then(mapIds) : Promise.resolve([ id ]);
-
     if (id !== null) {
       where[this.id] = id;
     }
 
     const options = Object.assign({}, params.sequelize, { where });
+
+    // This is the best way to implement patch in sql, the other dialects 'should' use a transaction.
+    if (this.dialect === 'postgres') {
+      options.returning = true;
+      return this.Model.update(omit(data, this.id), options)
+            .then((results) => {
+              // results[0] == changedCount
+              return results[1];
+            })
+            .then(select(params, this.id))
+            .catch(utils.errorHandler);
+    }
+
+    // By default we will just query for the one id. For multi patch
+    // we create a list of the ids of all items that will be changed
+    // to re-query them after the update
+    const ids = id === null ? this._find(params)
+        .then(mapIds) : Promise.resolve([ id ]);
 
     return ids
       .then(idList => {

--- a/src/index.js
+++ b/src/index.js
@@ -129,7 +129,7 @@ class Service {
     const options = Object.assign({}, params.sequelize, { where });
 
     // This is the best way to implement patch in sql, the other dialects 'should' use a transaction.
-    if (options.Model.sequelize.options.dialect === 'postgres') {
+    if (this.Model.sequelize.options.dialect === 'postgres') {
       options.returning = true;
       return this.Model.update(omit(data, this.id), options)
             .then(results => results[1])

--- a/src/index.js
+++ b/src/index.js
@@ -17,7 +17,6 @@ class Service {
 
     this.paginate = options.paginate || {};
     this.Model = options.Model;
-    this.dialect = options.Model.sequelize.options.dialect;
     this.id = options.id || 'id';
     this.events = options.events;
   }
@@ -130,13 +129,10 @@ class Service {
     const options = Object.assign({}, params.sequelize, { where });
 
     // This is the best way to implement patch in sql, the other dialects 'should' use a transaction.
-    if (this.dialect === 'postgres') {
+    if (options.Model.sequelize.options.dialect === 'postgres') {
       options.returning = true;
       return this.Model.update(omit(data, this.id), options)
-            .then((results) => {
-              // results[0] == changedCount
-              return results[1];
-            })
+            .then(results => results[1])
             .then(select(params, this.id))
             .catch(utils.errorHandler);
     }


### PR DESCRIPTION
### Summary

This PR utilizes the Sequelize [returning](http://docs.sequelizejs.com/en/v3/api/model/#updatevalues-options-promisearrayaffectedcount-affectedrows) option for update to do PATCH, in a single action. 

This is a non-breaking change.

### Other Information

The PATCH procedure for the other dialects _should_ probably also be reworked to use [transactions](http://docs.sequelizejs.com/en/latest/docs/transactions/), this may only cause problems on large scale deployments, but it is a potential issue.