### PR TITLE
Fix update no dao

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -165,7 +165,7 @@ class Service {
       return Promise.reject('Not replacing multiple records. Did you mean `patch`?');
     }
 
-    return this.Model.findById(id).then(instance => {
+    return this.Model.findById(id, {raw: false}).then(instance => {
       if (!instance) {
         throw new errors.NotFound(`No record found for id '${id}'`);
       }

--- a/src/index.js
+++ b/src/index.js
@@ -171,7 +171,7 @@ class Service {
       }
 
       let copy = {};
-      Object.keys(instance.toJSON()).forEach(key => {
+      Object.keys(typeof instance.toJSON === 'function' ? instance.toJSON() : instance).forEach(key => {
         if (typeof data[key] === 'undefined') {
           copy[key] = null;
         } else {

--- a/src/index.js
+++ b/src/index.js
@@ -170,6 +170,7 @@ class Service {
 
       let copy = {};
       Object.keys(typeof instance.toJSON === 'function' ? instance.toJSON() : instance).forEach(key => {
+        if (key === 'createdAt' || key === 'updatedAt') { return; }
         if (typeof data[key] === 'undefined') {
           copy[key] = null;
         } else {
@@ -177,16 +178,16 @@ class Service {
         }
       });
 
-      const where = { id };
+      const where = { [this.id]: id };
       const options = Object.assign({}, params.sequelize, { where });
 
       if (this.Model.sequelize.options.dialect === 'postgres') {
         options.returning = true;
-        return this.Model.update(copy, options)
+        return this.Model.update(omit(copy, this.id), options)
           .then(results => results[1]);
       }
 
-      return this.Model.update(copy, options)
+      return this.Model.update(omit(copy, this.id), options)
         .then(() => this._getOrFind(id, params));
     })
     .then(select(params, this.id))


### PR DESCRIPTION
### Force `raw: false` for the `findById` of the `update`. A DAO is required 

- [x] Tell us about the problem your pull request is solving.
When configured with `raw: true`, disable that setting for the `findById` part of the update as the DAO is required to perform the update
- [x] Are there any open issues that are related to this?
A closed one #99 
- [x] Is this PR dependent on PRs in other repos?
No

By setting `raw: false`, the change made in the previous PR (#100) might be useless, let me know if I should remove it before merging
