### PR TITLE
Update all methods to return plain JS objects

### DIFF
--- a/package.json
+++ b/package.json
@@ -76,7 +76,7 @@
     "eslint-if-supported": "^1.0.1",
     "feathers": "^2.0.0",
     "feathers-rest": "^1.3.0",
-    "feathers-service-tests": "^0.9.0",
+    "feathers-service-tests": "^0.10.0",
     "istanbul": "^1.1.0-alpha.1",
     "mocha": "^3.0.0",
     "rimraf": "^2.5.4",

--- a/src/hooks/dehydrate.js
+++ b/src/hooks/dehydrate.js
@@ -1,0 +1,35 @@
+const serialize = (item) => {
+  if (typeof item.toJSON === 'function') {
+    return item.toJSON();
+  }
+  return item;
+};
+
+export default () => {
+  return function (hook) {
+    switch (hook.method) {
+      case 'find':
+        if (hook.result.data) {
+          hook.result.data = hook.result.data.map(serialize);
+        } else {
+          hook.result = hook.result.map(serialize);
+        }
+        break;
+
+      case 'get':
+      case 'update':
+        hook.result = serialize(hook.result);
+        break;
+
+      case 'create':
+      case 'patch':
+        if (Array.isArray(hook.result)) {
+          hook.result = hook.result.map(serialize);
+        } else {
+          hook.result = serialize(hook.result);
+        }
+        break;
+    }
+    return Promise.resolve(hook);
+  };
+};

--- a/src/hooks/hydrate.js
+++ b/src/hooks/hydrate.js
@@ -1,0 +1,44 @@
+const factory = (Model, include = null) => {
+  return item => {
+    if (!(item instanceof Model.Instance)) {
+      return Model.build(item, { isNewRecord: false, include });
+    }
+    return item;
+  };
+};
+
+export default options => {
+  options = options || {};
+
+  return function (hook) {
+    if (hook.type !== 'after') {
+      throw new Error('feathers-sequelize hydrate() - should only be used as an "after" hook');
+    }
+
+    const makeInstance = factory(this.Model, options.include);
+    switch (hook.method) {
+      case 'find':
+        if (hook.result.data) {
+          hook.result.data = hook.result.data.map(makeInstance);
+        } else {
+          hook.result = hook.result.map(makeInstance);
+        }
+        break;
+
+      case 'get':
+      case 'update':
+        hook.result = makeInstance(hook.result);
+        break;
+
+      case 'create':
+      case 'patch':
+        if (Array.isArray(hook.result)) {
+          hook.result = hook.result.map(makeInstance);
+        } else {
+          hook.result = makeInstance(hook.result);
+        }
+        break;
+    }
+    return Promise.resolve(hook);
+  };
+};

--- a/test/hooks.dehydrate.test.js
+++ b/test/hooks.dehydrate.test.js
@@ -1,0 +1,106 @@
+import { expect } from 'chai';
+import dehydrate from '../src/hooks/dehydrate';
+import Sequelize from 'sequelize';
+
+const sequelize = new Sequelize('sequelize', '', '', {
+  dialect: 'sqlite',
+  storage: './db.sqlite',
+  logging: false
+});
+const BlogPost = sequelize.define('blogpost', {
+  title: {
+    type: Sequelize.STRING,
+    allowNull: false
+  }
+}, {
+  freezeTableName: true
+});
+const Comment = sequelize.define('comment', {
+  text: {
+    type: Sequelize.STRING,
+    allowNull: false
+  }
+}, {
+  freezeTableName: true
+});
+BlogPost.hasMany(Comment);
+Comment.belongsTo(BlogPost);
+
+const callHook = (Model, method, result, options) => {
+  if (result.data) {
+    result.data = result.data.map(item => Model.build(item, options));
+  } else if (Array.isArray(result)) {
+    result = result.map(item => Model.build(item, options));
+  } else {
+    result = Model.build(result, options);
+  }
+  return dehydrate().call({ Model }, {
+    type: 'after',
+    method,
+    result
+  });
+};
+
+describe('Feathers Sequelize Dehydrate Hook', () => {
+  before(() =>
+    sequelize.sync()
+  );
+
+  it('serializes results for find()', () => {
+    return callHook(BlogPost, 'find', [{title: 'David'}]).then(hook =>
+      expect(Object.getPrototypeOf(hook.result[0])).to.equal(Object.prototype)
+    );
+  });
+
+  it('serializes results for paginated find()', () => {
+    return callHook(BlogPost, 'find', {
+      data: [{title: 'David'}]
+    }).then(hook =>
+      expect(Object.getPrototypeOf(hook.result.data[0])).to.equal(Object.prototype)
+    );
+  });
+
+  it('serializes results for get()', () => {
+    return callHook(BlogPost, 'get', {title: 'David'}).then(hook =>
+      expect(Object.getPrototypeOf(hook.result)).to.equal(Object.prototype)
+    );
+  });
+
+  ['create', 'update', 'patch'].forEach(method => {
+    it(`serializes results for single ${method}()`, () => {
+      return callHook(BlogPost, method, {title: 'David'}).then(hook =>
+        expect(Object.getPrototypeOf(hook.result)).to.equal(Object.prototype)
+      );
+    });
+  });
+
+  ['create', 'patch'].forEach(method => {
+    it(`serializes results for bulk ${method}()`, () => {
+      return callHook(BlogPost, method, [{title: 'David'}]).then(hook =>
+        expect(Object.getPrototypeOf(hook.result[0])).to.equal(Object.prototype)
+      );
+    });
+  });
+
+  it('serializes included (associated) models', () => {
+    return callHook(BlogPost, 'get', {
+      title: 'David',
+      comments: [{ text: 'Comment text' }]
+    }, {
+      include: [Comment]
+    }).then(hook =>
+      expect(Object.getPrototypeOf(hook.result.comments[0])).to.equal(Object.prototype)
+    );
+  });
+
+  it('does not serialize if data is not a Model instance (with a toJSON method)', () => {
+    const result = { title: 'David' };
+    return dehydrate().call({ Model: BlogPost }, {
+      type: 'after',
+      method: 'get',
+      result
+    }).then(hook =>
+      expect(hook.result).to.equal(result)
+    );
+  });
+});

--- a/test/hooks.hydrate.test.js
+++ b/test/hooks.hydrate.test.js
@@ -1,0 +1,100 @@
+import { expect } from 'chai';
+import hydrate from '../src/hooks/hydrate';
+import Sequelize from 'sequelize';
+
+const sequelize = new Sequelize('sequelize', '', '', {
+  dialect: 'sqlite',
+  storage: './db.sqlite',
+  logging: false
+});
+const BlogPost = sequelize.define('blogpost', {
+  title: {
+    type: Sequelize.STRING,
+    allowNull: false
+  }
+}, {
+  freezeTableName: true
+});
+const Comment = sequelize.define('comment', {
+  text: {
+    type: Sequelize.STRING,
+    allowNull: false
+  }
+}, {
+  freezeTableName: true
+});
+BlogPost.hasMany(Comment);
+Comment.belongsTo(BlogPost);
+
+const callHook = (Model, method, result, options) => {
+  return hydrate(options).call({ Model }, {
+    type: 'after',
+    method,
+    result
+  });
+};
+
+describe('Feathers Sequelize Hydrate Hook', () => {
+  before(() =>
+    sequelize.sync()
+  );
+
+  it('throws if used as a "before" hook', () => {
+    const hook = hydrate().bind(null, { type: 'before' });
+    expect(hook).to.throw(Error);
+  });
+
+  it('hydrates results for find()', () => {
+    return callHook(BlogPost, 'find', [{title: 'David'}]).then(hook =>
+      expect(hook.result[0] instanceof BlogPost.Instance).to.be.ok
+    );
+  });
+
+  it('hydrates results for paginated find()', () => {
+    return callHook(BlogPost, 'find', {
+      data: [{title: 'David'}]
+    }).then(hook =>
+      expect(hook.result.data[0] instanceof BlogPost.Instance).to.be.ok
+    );
+  });
+
+  it('hydrates results for get()', () => {
+    return callHook(BlogPost, 'get', {title: 'David'}).then(hook =>
+      expect(hook.result instanceof BlogPost.Instance).to.be.ok
+    );
+  });
+
+  ['create', 'update', 'patch'].forEach(method => {
+    it(`hydrates results for single ${method}()`, () => {
+      return callHook(BlogPost, method, {title: 'David'}).then(hook =>
+        expect(hook.result instanceof BlogPost.Instance).to.be.ok
+      );
+    });
+  });
+
+  ['create', 'patch'].forEach(method => {
+    it(`hydrates results for bulk ${method}()`, () => {
+      return callHook(BlogPost, method, [{title: 'David'}]).then(hook =>
+        expect(hook.result[0] instanceof BlogPost.Instance).to.be.ok
+      );
+    });
+  });
+
+  it('hydrates included (associated) models', () => {
+    return callHook(BlogPost, 'get', {
+      title: 'David',
+      comments: [{ text: 'Comment text' }]
+    }, {
+      include: [Comment]
+    }).then(hook =>
+      expect(hook.result.comments[0] instanceof Comment.Instance).to.be.ok
+    );
+  });
+
+  it('does not hydrate if data is a Model instance', () => {
+    const instance = BlogPost.build({ title: 'David' });
+    return callHook(BlogPost, 'get', instance).then(hook =>
+      expect(hook.result).to.equal(instance)
+    );
+  });
+});

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -1,6 +1,6 @@
 import assert from 'assert';
 import { expect } from 'chai';
-import { base, example } from 'feathers-service-tests';
+import { base, example, orm } from 'feathers-service-tests';
 import Sequelize from 'sequelize';
 import errors from 'feathers-errors';
 import feathers from 'feathers';
@@ -95,6 +95,69 @@ describe('Feathers Sequelize Service', () => {
 
     base(app, errors);
     base(app, errors, 'people-customid', 'customid');
+  });
+
+  describe('ORM functionality', () => {
+    const app = feathers()
+      .use('/people', service({
+        Model,
+        events: [ 'testing' ]
+      }));
+    const people = app.service('people');
+
+    describe('Model Instance queries', () => {
+      const _ids = {};
+      const _data = {};
+
+      beforeEach(() =>
+        people.create({name: 'David'}).then(result => {
+          _data.David = result;
+          _ids.David = result.id;
+        })
+      );
+
+      afterEach(() =>
+        people.remove(_ids.David)
+      );
+
+      it('`raw: false` works for find()', () =>
+        people.find({sequelize: {raw: false}}).then(results =>
+          expect(results[0] instanceof Model.Instance).to.be.ok
+        )
+      );
+
+      it('`raw: false` works for get()', () =>
+        people.get(_ids.David, {sequelize: {raw: false}}).then(instance =>
+          expect(instance instanceof Model.Instance).to.be.ok
+        )
+      );
+
+      it('`raw: false` works for create()', () =>
+        people.create({name: 'Sarah'}, {sequelize: {raw: false}}).then(instance =>
+          expect(instance instanceof Model.Instance).to.be.ok
+        )
+      );
+
+      it('`raw: false` works for bulk create()', () =>
+        people.create([{name: 'Sarah'}], {sequelize: {raw: false}}).then(results =>
+          expect(results[0] instanceof Model.Instance).to.be.ok
+        )
+      );
+
+      it('`raw: false` works for patch()', () =>
+        people.patch(_ids.David, {name: 'Sarah'}, {sequelize: {raw: false}}).then(instance =>
+          expect(instance instanceof Model.Instance).to.be.ok
+        )
+      );
+
+      it('`raw: false` works for update()', () =>
+        people.update(_ids.David, _data.David, {sequelize: {raw: false}}).then(instance =>
+          expect(instance instanceof Model.Instance).to.be.ok
+        )
+      );
+    });
+
+    orm(people, errors);
   });
 });
 


### PR DESCRIPTION
### Summary

This updates all service methods to return plain javascript objects by default (`{ raw: true }`). **This is a breaking change** (see below for an easy fix).

This ensures that feathers-sequelize will play nicely and consistently with common hooks and other 3rd party hooks and integrations. Users can pass `{ raw: false }` to any of the service methods and get ORM-wrapped objects if they so choose. There are tests covering this new functionality located in [this PR in feathers-service-hooks](https://github.com/feathersjs/feathers-service-tests/pull/39).

This PR also includes hooks so users can easily `hydrate` hook results into ORM objects and conversely `dehydrate` those objects back into plain javascript objects.

```js
const hydrate = require('feathers-sequelize/hooks/hydrate');
const dehydrate = require('feathers-sequelize/hooks/dehydrate');
const { populate } = require('feathers-hooks-common');

hooks.after.find = [hydrate(), doSomethingCustom(), dehydrate(), populate()];
```

The conversation around this issue is spread out across multiple issues in multiple repositories. This is my best attempt to aggregate this conversion:

https://github.com/feathersjs/feathers-sequelize/issues/18
https://github.com/feathersjs/feathers-sequelize/issues/19
https://github.com/feathersjs/feathers-sequelize/issues/24
https://github.com/feathersjs/feathers-hooks-common/issues/144
https://github.com/feathersjs/feathers-hooks-common/pull/146
https://github.com/feathersjs/feathers-hooks-common/issues/150