### PR TITLE
Issue #113: Model.create ignoring field and virtual setters

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -113,13 +113,19 @@ class Service {
 
   create (data, params) {
     const options = Object.assign({raw: this.raw}, params.sequelize);
+    // Model.create's `raw` option is different from other methods.
+    // In order to use `raw` consistently to serialize the result,
+    // we need to shadow the Model.create use of raw, which we provide
+    // access to by specifying `ignoreSetters`.
+    const ignoreSetters = Boolean(options.ignoreSetters);
+    const createOptions = Object.assign({}, options, {raw: ignoreSetters});
     const isArray = Array.isArray(data);
     let promise;
 
     if (isArray) {
-      promise = this.Model.bulkCreate(data, options);
+      promise = this.Model.bulkCreate(data, createOptions);
     } else {
-      promise = this.Model.create(data, options);
+      promise = this.Model.create(data, createOptions);
     }
 
     return promise.then(result => {


### PR DESCRIPTION
This PR solves the problem by making the behaviour of feathers-sequelize's `raw` parameter consistent across service methods and take priority over the behaviour of sequelize's `raw` parameter for Model.create calls (in which `raw` means something completely different). It introduces a `sequelize.ignoreSetters` argument to control the shadowed Model.create `raw` parameter.

Without this PR, the following behaviour is observed:
- `service.create(data)` — setters ignored
- `service.create(data, {raw: false})` — setters called, but DAO returned

The desired default behaviour is to have setters called but JSON returned, which this PR achieves. To get the native behaviour of calling `Model.create({raw: true})`, you can now call:
`service.create(data, {sequelize: {ignoreSetters: true}})`

This PR should be accompanied by a corresponding update to the docs to describe the new `ignoreSetters` argument: https://docs.feathersjs.com/api/databases/sequelize.html