### PR TITLE
Fix issue with custom ID when using eager loading

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -44,6 +44,10 @@ export function getOrder (sort = {}) {
 export function getWhere (query) {
   let where = Object.assign({}, query);
 
+  if (where.$select) {
+    delete where.$select;
+  }
+
   Object.keys(where).forEach(prop => {
     let value = where[prop];
     if (value && value.$nin) {


### PR DESCRIPTION
### Summary

This fixes #122 by using the configured `id` key. The source of this bug is the fact that we had a separate code path for eager loading. This PR not only fixes the issue, it also gets rid of the extra code path so as to mitigate a similar issue in the future.

Under the hood, sequelize uses `findAll` for making queries for `findById` and `findOne`. So we just use `findAll` for loading data by id.