### PR TITLE
fix(hydrate): Fix the factory function so that Sequelize 4.x is supported

### DIFF
--- a/src/hooks/hydrate.js
+++ b/src/hooks/hydrate.js
@@ -1,8 +1,16 @@
 const factory = (Model, include = null) => {
   return item => {
-    if (!(item instanceof Model.Instance)) {
+    // (Darren): We have to check that the Model.Instance static property exists
+    // first since it's been deprecated in Sequelize 4.x.
+    // See: http://docs.sequelizejs.com/manual/tutorial/upgrade-to-v4.html
+    var shouldBuild = Model.Instance
+      ? !(item instanceof Model.Instance)
+      : !(item instanceof Model);
+
+    if (shouldBuild) {
       return Model.build(item, { isNewRecord: false, include });
     }
+
     return item;
   };
 };

--- a/src/hooks/hydrate.js
+++ b/src/hooks/hydrate.js
@@ -3,7 +3,7 @@ const factory = (Model, include = null) => {
     // (Darren): We have to check that the Model.Instance static property exists
     // first since it's been deprecated in Sequelize 4.x.
     // See: http://docs.sequelizejs.com/manual/tutorial/upgrade-to-v4.html
-    var shouldBuild = Model.Instance
+    const shouldBuild = Model.Instance
       ? !(item instanceof Model.Instance)
       : !(item instanceof Model);
 


### PR DESCRIPTION
Since Sequelize 4.x the Model.Instance static property has been deprecated. Instead you need to use the Model directly (i.e. `item instanceof Model` instead of `item instanceof Model.Instance`).

See: http://docs.sequelizejs.com/manual/tutorial/upgrade-to-v4.html

Add a check to see if Model.Instance exists before using it so that Sequelize 4.x is supported.
Add instanceof check for Model to support Sequelize 4.x.

See issue #138