### PR TITLE
Use hook.service instead of 'this'

### DIFF
--- a/src/hooks/hydrate.js
+++ b/src/hooks/hydrate.js
@@ -23,7 +23,7 @@ export default options => {
       throw new Error('feathers-sequelize hydrate() - should only be used as an "after" hook');
     }
 
-    const makeInstance = factory(this.Model, options.include);
+    const makeInstance = factory(hook.service.Model, options.include);
     switch (hook.method) {
       case 'find':
         if (hook.result.data) {


### PR DESCRIPTION
If the hook is defined as an arrow function (=>), then "this" will be the context in which the arrow function was defined, not the current service.

Using hook.service is guaranteed to return the current service.