### PR TITLE
Extend test coverage

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,8 @@ node_js:
   - node
   - '6'
   - '4'
+env:
+  - DB=postgres
 sudo: false
 before_script:
   - npm install -g codeclimate-test-reporter

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,7 @@ sudo: false
 before_script:
   - npm install -g codeclimate-test-reporter
   - psql -c 'create database sequelize;' -U postgres
+  - mysql -e 'CREATE DATABASE sequelize;'
 after_script:
   - codeclimate-test-reporter < coverage/lcov.info
 services:

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,8 @@ node_js:
   - '4'
 env:
   - DB=postgres
+  - DB=mysql
+  - DB=sqlite
 sudo: false
 before_script:
   - npm install -g codeclimate-test-reporter

--- a/package.json
+++ b/package.json
@@ -45,7 +45,9 @@
     "lint": "eslint-if-supported semistandard --fix",
     "mocha": "mocha --opts mocha.opts --timeout 5000",
     "test": "npm run lint && npm run coverage",
-    "coverage": "istanbul cover node_modules/mocha/bin/_mocha -- --opts mocha.opts"
+    "test:postgres": "env DB=postgres npm run lint && npm run coverage:postgres",
+    "coverage": "istanbul cover node_modules/mocha/bin/_mocha -- --opts mocha.opts",
+    "coverage:postgres": "env DB=postgres istanbul cover node_modules/mocha/bin/_mocha -- --opts mocha.opts"
   },
   "semistandard": {
     "env": [

--- a/package.json
+++ b/package.json
@@ -46,8 +46,10 @@
     "mocha": "mocha --opts mocha.opts --timeout 5000",
     "test": "npm run lint && npm run coverage",
     "test:postgres": "env DB=postgres npm run lint && npm run coverage:postgres",
+    "test:mysql": "env DB=mysql npm run lint && npm run coverage:mysql",
     "coverage": "istanbul cover node_modules/mocha/bin/_mocha -- --opts mocha.opts",
-    "coverage:postgres": "env DB=postgres istanbul cover node_modules/mocha/bin/_mocha -- --opts mocha.opts"
+    "coverage:postgres": "env DB=postgres istanbul cover node_modules/mocha/bin/_mocha -- --opts mocha.opts",
+    "coverage:mysql": "env DB=mysql istanbul cover node_modules/mocha/bin/_mocha -- --opts mocha.opts"
   },
   "semistandard": {
     "env": [
@@ -82,6 +84,7 @@
     "feathers-service-tests": "^0.10.0",
     "istanbul": "^1.1.0-alpha.1",
     "mocha": "^3.0.0",
+    "mysql2": "^1.4.2",
     "pg": "^6.1.5",
     "pg-hstore": "^2.3.2",
     "rimraf": "^2.5.4",

--- a/src/index.js
+++ b/src/index.js
@@ -150,7 +150,7 @@ class Service {
       where[this.id] = id;
     }
 
-    const options = Object.assign({}, params.sequelize, { where });
+    const options = Object.assign({raw: this.raw}, params.sequelize, { where });
 
     let Model = this.applyScope(params);
 

--- a/test/hooks.dehydrate.test.js
+++ b/test/hooks.dehydrate.test.js
@@ -2,11 +2,26 @@ import { expect } from 'chai';
 import dehydrate from '../src/hooks/dehydrate';
 import Sequelize from 'sequelize';
 
-const sequelize = new Sequelize('sequelize', '', '', {
-  dialect: 'sqlite',
-  storage: './db.sqlite',
-  logging: false
-});
+let sequelize;
+
+if (process.env.DB === 'postgres') {
+  sequelize = new Sequelize('sequelize', 'postgres', '', {
+    host: 'localhost',
+    dialect: 'postgres'
+  });
+} else if (process.env.DB === 'mysql') {
+  sequelize = new Sequelize('sequelize', 'root', '', {
+    host: '127.0.0.1',
+    dialect: 'mysql'
+  });
+} else {
+  sequelize = new Sequelize('sequelize', '', '', {
+    dialect: 'sqlite',
+    storage: './db.sqlite',
+    logging: false
+  });
+}
+
 const BlogPost = sequelize.define('blogpost', {
   title: {
     type: Sequelize.STRING,

--- a/test/hooks.hydrate.test.js
+++ b/test/hooks.hydrate.test.js
@@ -2,11 +2,26 @@ import { expect } from 'chai';
 import hydrate from '../src/hooks/hydrate';
 import Sequelize from 'sequelize';
 
-const sequelize = new Sequelize('sequelize', '', '', {
-  dialect: 'sqlite',
-  storage: './db.sqlite',
-  logging: false
-});
+let sequelize;
+
+if (process.env.DB === 'postgres') {
+  sequelize = new Sequelize('sequelize', 'postgres', '', {
+    host: 'localhost',
+    dialect: 'postgres'
+  });
+} else if (process.env.DB === 'mysql') {
+  sequelize = new Sequelize('sequelize', 'root', '', {
+    host: '127.0.0.1',
+    dialect: 'mysql'
+  });
+} else {
+  sequelize = new Sequelize('sequelize', '', '', {
+    dialect: 'sqlite',
+    storage: './db.sqlite',
+    logging: false
+  });
+}
+
 const BlogPost = sequelize.define('blogpost', {
   title: {
     type: Sequelize.STRING,

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -14,15 +14,20 @@ import server from '../example/app';
 // https://github.com/sequelize/sequelize/issues/1774
 pg.defaults.parseInt8 = true;
 
-const sequelize = new Sequelize('sequelize', '', '', {
-  dialect: 'sqlite',
-  storage: './db.sqlite',
-  logging: false
-});
-const postgres = new Sequelize('sequelize', 'postgres', '', {
-  host: 'localhost',
-  dialect: 'postgres'
-});
+let sequelize;
+
+if (process.env.DB === 'postgres') {
+  sequelize = new Sequelize('sequelize', 'postgres', '', {
+    host: 'localhost',
+    dialect: 'postgres'
+  });
+} else {
+  sequelize = new Sequelize('sequelize', '', '', {
+    dialect: 'sqlite',
+    storage: './db.sqlite',
+    logging: false
+  });
+}
 
 const Model = sequelize.define('people', {
   name: {
@@ -36,7 +41,7 @@ const Model = sequelize.define('people', {
     type: Sequelize.BOOLEAN
   },
   time: {
-    type: Sequelize.INTEGER
+    type: Sequelize.BIGINT
   },
   status: {
     type: Sequelize.STRING,
@@ -57,23 +62,6 @@ const Model = sequelize.define('people', {
     }
   }
 });
-const PostgresModel = postgres.define('people', {
-  name: {
-    type: Sequelize.STRING,
-    allowNull: false
-  },
-  age: {
-    type: Sequelize.INTEGER
-  },
-  created: {
-    type: Sequelize.BOOLEAN
-  },
-  time: {
-    type: Sequelize.BIGINT
-  }
-}, {
-  freezeTableName: true
-});
 const CustomId = sequelize.define('people-customid', {
   customid: {
     type: Sequelize.INTEGER,
@@ -91,7 +79,7 @@ const CustomId = sequelize.define('people-customid', {
     type: Sequelize.BOOLEAN
   },
   time: {
-    type: Sequelize.INTEGER
+    type: Sequelize.BIGINT
   }
 }, {
   freezeTableName: true
@@ -333,17 +321,6 @@ describe('Feathers Sequelize Service', () => {
         )
       );
     });
-  });
-
-  describe('PostgreSQL', () => {
-    const app = feathers()
-      .use('/people', service({
-        Model: PostgresModel,
-        events: [ 'testing' ]
-      }));
-
-    before(() => PostgresModel.sync({ force: true }));
-    base(app, errors);
   });
 });
 

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -21,6 +21,11 @@ if (process.env.DB === 'postgres') {
     host: 'localhost',
     dialect: 'postgres'
   });
+} else if (process.env.DB === 'mysql') {
+  sequelize = new Sequelize('sequelize', 'root', '', {
+    host: '127.0.0.1',
+    dialect: 'mysql'
+  });
 } else {
   sequelize = new Sequelize('sequelize', '', '', {
     dialect: 'sqlite',


### PR DESCRIPTION
1. Removed the separate tests for postgres. Tests now run against the DB specified by the 'DB' environment variable and default to sqllite.

2. Added Travis CI configuration so that tests are run against postgres, mysql and sqllite.

Related issues:

https://github.com/feathersjs/feathers-sequelize/issues/154